### PR TITLE
GitHub Pagesにデプロイするためのワークフロー作成

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup node 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - name: install
+        run: npm install
+
+      - name: build
+        run: npm run build
+
+      - name: deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
## 変更点
- GitHub Pagesにデプロイするためのワークフロー作成

https://github.com/kanazawa-js/kanazawa-js.github.io/issues/74 の対応です。

## 備考
https://kanazawa-js.github.io/

↑今後は上記にデプロイされます。すでにお試しでデプロイ済みです。